### PR TITLE
Implement CLI and tests for Task Scheduler App (#3)

### DIFF
--- a/calendar_app/README.md
+++ b/calendar_app/README.md
@@ -1,1 +1,10 @@
 # lab13-sprint-full-stack-slop-llc
+
+# To run main:
+# cd calendar_app
+# python3 -m src.calendar_app_package.main
+
+
+# To run tests:
+# source venv/bin/activate
+# PYTHONPATH=calendar_app/src ~/.local/bin/pytest calendar_app/tests/test_main.py

--- a/calendar_app/src/calendar_app_package/calendar_api.py
+++ b/calendar_app/src/calendar_app_package/calendar_api.py
@@ -1,5 +1,6 @@
 import os
 import pickle
+import json
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 

--- a/calendar_app/src/calendar_app_package/main.py
+++ b/calendar_app/src/calendar_app_package/main.py
@@ -1,38 +1,49 @@
-from manager import TaskManager
-from calendar_api import GoogleCalendarAPI
+from .manager import TaskManager
+from .calendar_api import calendar_api
 
 def main():
     manager = TaskManager()
-    calendar_api = GoogleCalendarAPI()
+    calendar = calendar_api()
 
     print("Welcome to the Task Scheduler App")
 
     while True:
-        print("\n1. Add Task")
+        print("\nMenu:")
+        print("1. Add Task")
         print("2. View Tasks")
         print("3. Exit")
 
         choice = input("Choose an option: ").strip()
 
         if choice == '1':
-            title = input("Task Title: ")
-            description = input("Task Description: ")
-            start_time = input("Start Time (YYYY-MM-DDTHH:MM:SS): ")
-            end_time = input("End Time (YYYY-MM-DDTHH:MM:SS): ")
+            title = input("Task Title: ").strip()
+            description = input("Task Description: ").strip()
+            start_time = input("Start Time (YYYY-MM-DDTHH:MM:SS): ").strip()
+            end_time = input("End Time (YYYY-MM-DDTHH:MM:SS): ").strip()
 
-            task = manager.add_task(title, description, start_time, end_time)
-            link = calendar_api.create_event(task)
-            print(f"Task created and added to Google Calendar.\nEvent link: {link}")
+            try:
+                task = manager.add_task(title, description, start_time, end_time)
+                link = calendar.create_event(task)
+                print("\nTask created and added to Google Calendar.")
+                print(f"Event link: {link}")
+            except Exception as e:
+                print(f"\nFailed to create task or event: {e}")
 
         elif choice == '2':
             tasks = manager.list_tasks()
-            for task in tasks:
-                print(task)
+            if tasks:
+                print("\nTask List:")
+                for task in tasks:
+                    print(task)
+            else:
+                print("No tasks added yet.")
 
         elif choice == '3':
+            print("Goodbye!")
             break
+
         else:
-            print("Invalid choice.")
+            print("Invalid choice. Please enter 1, 2, or 3.")
 
 if __name__ == '__main__':
     main()

--- a/calendar_app/src/calendar_app_package/manager.py
+++ b/calendar_app/src/calendar_app_package/manager.py
@@ -1,1 +1,13 @@
-print("init")
+from .task import Task
+
+class TaskManager:
+    def __init__(self):
+        self.tasks = []
+
+    def add_task(self, title, description, start_time, end_time):
+        task = Task(title, description, start_time, end_time)
+        self.tasks.append(task)
+        return task
+
+    def list_tasks(self):
+        return self.tasks

--- a/calendar_app/tests/test_main.py
+++ b/calendar_app/tests/test_main.py
@@ -1,0 +1,54 @@
+import pytest
+from calendar_app_package import main as app_main
+
+def test_cli_add_task_and_exit(monkeypatch, capsys):
+    inputs = iter([
+        '1',                      # Add Task
+        'Test Task',             # Title
+        'Test Description',      # Description
+        '2025-04-20T10:00:00',   # Start time
+        '2025-04-20T11:00:00',   # End time
+        '3'                      # Exit
+    ])
+    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+
+    class MockCalendarAPI:
+        def create_event(self, task):
+            return "https://calendar.google.com/fake-link"
+
+    monkeypatch.setattr("calendar_app_package.main.calendar_api", MockCalendarAPI)
+
+    app_main.main()
+    output = capsys.readouterr().out
+    assert "Task created and added to Google Calendar." in output
+    assert "https://calendar.google.com/fake-link" in output
+
+def test_cli_view_tasks_and_exit(monkeypatch, capsys):
+    inputs = iter(['2', '3'])  # View → Exit
+    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+
+    class MockTask:
+        def __str__(self):
+            return "Mock Task: 2025-04-21T10:00:00 → 2025-04-21T11:00:00"
+
+    class MockTaskManager:
+        def __init__(self):
+            pass
+        def list_tasks(self):
+            return [MockTask()]
+        def add_task(self, *args, **kwargs):
+            return MockTask()
+
+    class MockCalendarAPI:
+        def create_event(self, task):
+            return "https://calendar.google.com/fake-link"
+
+    # ✅ Correct patching based on actual class names used in main.py
+    monkeypatch.setattr("calendar_app_package.main.TaskManager", MockTaskManager)
+    monkeypatch.setattr("calendar_app_package.main.calendar_api", MockCalendarAPI)
+
+    app_main.main()
+
+    output = capsys.readouterr().out
+    assert "Task List:" in output
+    assert "Mock Task" in output


### PR DESCRIPTION
This PR implements the command-line interface for the Task Scheduler app.

 Features:
- Add task via user input (title, description, start/end time)
- Create events via Google Calendar API
- View stored tasks
- Print confirmation link for event

Testing:
- Two tests added in `test_main.py` using monkeypatch and capsys
- Coverage includes task creation and task viewing

Closes #3
